### PR TITLE
For python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Pic2
 ## Installation. 
 To use this exporter you need Python2.7 or Python3.x and its modules prometheus_client, psutil.
  
-###Solaris 10u11:  
+### Solaris 10u11:  
     # Setup proxy vars to have access to internet  
         export http_proxy=http://proxy.example.com:3128  
         export https_proxy=http://proxy.example.com:3128  
@@ -66,7 +66,7 @@ To use this exporter you need Python2.7 or Python3.x and its modules prometheus_
             # pip3 is not included in pkgutil, we need to install it by hands  
             # download pip3.3 installer [https://bootstrap.pypa.io/pip/3.3/get-pip.py] and run it with python3.3  
             /opt/csw/bin/python3.3 get-pip.py  
-    #Install gcc5core  
+    # Install gcc5core  
         /opt/csw/bin/pkgutil -y -i gcc5core  
     # Install Python module prometheus_client  
         # Python 2.7  
@@ -90,7 +90,7 @@ To use this exporter you need Python2.7 or Python3.x and its modules prometheus_
         /opt/csw/bin/python3.3 solaris_exporter.py  
  
  
-####Solaris 11.4.4 (this way works with Python 2.7):  
+#### Solaris 11.4.4 (this way works with Python 2.7):  
     # Setup proxy vars to have access to internet  
         export http_proxy=http://proxy.example.com:3128  
         export https_proxy=http://proxy.example.com:3128  
@@ -110,7 +110,7 @@ To use this exporter you need Python2.7 or Python3.x and its modules prometheus_
         python2.7 solaris_exporter.py  
  
  
-####Solaris 11.4.41 (this way works with Python 3.7):  
+#### Solaris 11.4.41 (this way works with Python 3.7):  
     # Setup proxy vars to have access to internet  
             export http_proxy=http://proxy.example.com:3128  
             export https_proxy=http://proxy.example.com:3128  

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Pic2
 ## Installation. 
 To use this exporter you need Python2.7 or Python3.x and its modules prometheus_client, psutil.
  
-###Solaris 10u11:
+###Solaris 10u11:  
     # Setup proxy vars to have access to internet  
         export http_proxy=http://proxy.example.com:3128  
         export https_proxy=http://proxy.example.com:3128  
@@ -90,7 +90,7 @@ To use this exporter you need Python2.7 or Python3.x and its modules prometheus_
         /opt/csw/bin/python3.3 solaris_exporter.py  
  
  
-####Solaris 11.4.4 (this way works with Python 2.7, it is included in this release):
+####Solaris 11.4.4 (this way works with Python 2.7):  
     # Setup proxy vars to have access to internet  
         export http_proxy=http://proxy.example.com:3128  
         export https_proxy=http://proxy.example.com:3128  
@@ -110,7 +110,7 @@ To use this exporter you need Python2.7 or Python3.x and its modules prometheus_
         python2.7 solaris_exporter.py  
  
  
-####Solaris 11.4.41 (this way works with Python 3.7):
+####Solaris 11.4.41 (this way works with Python 3.7):  
     # Setup proxy vars to have access to internet  
             export http_proxy=http://proxy.example.com:3128  
             export https_proxy=http://proxy.example.com:3128  

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Also work on x86 platform, community-tested with Openindiana (x86) (OI-hipster-m
  - 2020 Dec 17. Added PrtdiagCollector, MetaStatCollector, MetaDBCollector
  - 2021 Jan 05. Added TextFileCollector, SVCSCollector now enabled for all zones (Thanks to Marcel Peter)
  - 2021 Mar 01. Fixed psutil version to 5.7.0 (something changed in the newer versions, have to time to look at)
+ - 2022 Jan 24. Added support for Python 3. In testing.
+ - 2022 Feb 04. Documentation update for support of Solaris 11.4.41. In testing.
 
 ## Provides info about:
   - Solaris Zones CPU Usage with processor sets info (PerZoneCpuCollector);
@@ -41,44 +43,89 @@ Pic2
 ![](sol-exporter-graph2.jpg)
 
 ## Installation. 
-To use this exporter you need python2.7 and its modules prometheus_client, psutil.
+To use this exporter you need Python2.7 or Python3.x and its modules prometheus_client, psutil.
 
-### Solaris 10u11:
-    # Setup proxy vars to have access to internet   
-        export http_proxy=http://<user>:<password>@proxy.example.com:3128  
-        export https_proxy=https://<user>:<password>@proxy.example.com:3128  
-    # Install pkgutil    
-        wget http://get.opencsw.org/now 
-        pkgadd -d ./now
-    # Update repo list and install 'py_pip', 'python27', 'python27_dev', 'gcc5core'  
-        /opt/csw/bin/pkgutil -U  
-        /opt/csw/bin/pkgutil -y -i py_pip  
-        /usr/sbin/pkgchk -L CSWpy-pip               # list installed files if you need  
-        /opt/csw/bin/pkgutil -y -i python27  
-        /opt/csw/bin/pkgutil -y -i python27_dev  
-        /opt/csw/bin/pkgutil -y -i gcc5core  
-    # Install Python 2.7 module prometheus_client, it installes eassily.  
-        /opt/csw/bin/pip2.7 install prometheus_client   
-    # Install Python 2.7 module psutil, it have to compile some libs, but we preinstalled all that needed  
-        ln -s /opt/csw/bin/gcc-5.5 /opt/csw/bin/gcc-5.2  
-        /opt/csw/bin/pip2.7 install psutil==5.7.0  
-    # Run exporter, check http://ip:9100  
-        /opt/csw/bin/python2.7 solaris_exporter.py  
+###Solaris 10u11:
+        # Setup proxy vars to have access to internet
+            export http_proxy=http://proxy.example.com:3128
+            export https_proxy=http://proxy.example.com:3128
+        # Install pkgutil
+            wget http://get.opencsw.org/now 
+            pkgadd -d ./now
+        # Update repo list
+            /opt/csw/bin/pkgutil -U
+        # Install Python 2.7 or Python 3.3 (it works on both)
+            # Python 2.7 (preferred)
+                /opt/csw/bin/pkgutil -y -i python27
+                /opt/csw/bin/pkgutil -y -i python27_dev
+                /opt/csw/bin/pkgutil -y -i py_pip
+                /usr/sbin/pkgchk -L CSWpy-pip               # list installed files if you need
+            # or Python 3.3
+                /opt/csw/bin/pkgutil -y -i python33
+                /opt/csw/bin/pkgutil -y -i python33_dev
+                # pip3 is not included in pkgutil, we need to install it by hands
+                # download pip3.3 installer [https://bootstrap.pypa.io/pip/3.3/get-pip.py] and run it with python3.3
+                /opt/csw/bin/python3.3 get-pip.py
+        #Install gcc5core
+            /opt/csw/bin/pkgutil -y -i gcc5core
+        # Install Python module prometheus_client, it installes eassily.
+            # Python 2.7
+                /opt/csw/bin/pip2.7 install prometheus_client
+            # or Python 3.3
+                /opt/csw/bin/pip3.3 install prometheus_client
+        # Install Python module psutil, it have to compile some libs, but we preinstalled all that needed
+            ln -s /opt/csw/bin/gcc-5.5 /opt/csw/bin/gcc-5.2
+            # Python 2.7
+                # note that the latest version of psutil not supports Python2.7,
+                # that is why version of psutil is fixed to '5.7.0'
+                    /opt/csw/bin/pip2.7 install psutil==5.7.0
+            # or Python 3.3
+                /opt/csw/bin/pip3.3 install psutil
+        # Run exporter, check http://ip:9100
+            # Python 2.7
+            export LANG=C
+            /opt/csw/bin/python2.7 solaris_exporter.py
+            # or Python 3.3
+            export LANG=C
+            /opt/csw/bin/python3.3 solaris_exporter.py
 
-### Solaris 11.4:
-    # Setup proxy vars to have access to internet  
-        export https_proxy=https://proxy.example.com:3128  
-    # Install Python 2.7 module prometheus_client, it installes eassily.  
-        pip install prometheus_client  
-    # Install Python 2.7 module psutil, it have to compile some libs  
-    # Also you could get psutil via 'pkg install library/python/psutil-27',  
-    # but it returns wrong Network statistics, tested from Solaris 11.4.4 repo.  
-        pkg install pkg:/developer/gcc/gcc-c-5  
-        ln -s /usr/bin/gcc /usr/bin/cc  
-        export CFLAGS=-m32  
-        pip install psutil==5.7.0  
-    # Run exporter, check http://ip:9100  
-        python2.7 solaris_exporter.py  
+
+####Solaris 11.4.4 (this way works with Python 2.7, it is included in this release):
+        # Setup proxy vars to have access to internet
+            export http_proxy=http://proxy.example.com:3128
+            export https_proxy=http://proxy.example.com:3128
+        # Install Python 2.7 module prometheus_client, it installs easy.
+            pip-2.7 install prometheus_client
+        # Install Python 2.7 module psutil, it have to compile some libs
+        # Also you could get psutil for Python 2.7 via 'pkg install library/python/psutil-27',
+        # but it returns wrong Network statistics, tested from Solaris 11.4.4 repo.
+        # The latest version of psutil not supports Python2.7, that is why version of psutil is fixed on '5.7.0'
+            pkg install pkg:/developer/gcc/gcc-c-5
+            ln -s /usr/bin/gcc /usr/bin/cc
+            export CFLAGS=-m32
+            pip-2.7 install psutil==5.7.0
+            # if you have troubeles with compilation, try to switch to gcc-c-5 and Python 3.7 
+        # Run exporter, check http://ip:9100
+            export LANG=C
+            python2.7 solaris_exporter.py
+
+
+####Solaris 11.4.41 (this way works with Python 3.7):
+        # Setup proxy vars to have access to internet
+            export http_proxy=http://proxy.example.com:3128
+            export https_proxy=http://proxy.example.com:3128
+        # Install Python 3.7 module prometheus_client, it installs easу.
+            pip-3.7 install prometheus_client
+        # Install Python 3.7 module psutil
+        # Also you could get psutil for Python 3.7 via 'pkg install library/python/psutil-37',
+        # but its old version '5.6.7' returns wrong Network statistics, tested from Solaris 11.4.41 repo.
+        # The best way is to install actual version of psutil (tested on '5.9.0') 
+            pkg install pkg:/developer/gcc/gcc-c-9
+            ln -s /usr/bin/gcc /usr/bin/cc
+            pip-3.7 install psutil==5.9.0
+        # Run exporter, check http://ip:9100
+            export LANG=C
+            python3.7 solaris_exporter.py
 
 ## SMF, Roles, Deployment. 
  - Create user and group '**monitor**'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Description
 SPARC solaris exporter for Prometheus.   
 Written by Alexander Golikov for collecting SPARC Solaris metrics for Prometheus.  
-Tested on Solaris 11.3.25, 11.4.4, 10u11(limited) SPARC.  
+Tested on Solaris 11.3.25, 11.4.4, 11.4.41, 10u11(limited) SPARC.  
 Also work on x86 platform, community-tested with Openindiana (x86) (OI-hipster-minimal-20201031.iso) and Solaris10u11. 
 
 ## versions
@@ -12,9 +12,10 @@ Also work on x86 platform, community-tested with Openindiana (x86) (OI-hipster-m
  - 2020 Feb 09. Added DiskErrorCollector, ZpoolCollector, FmadmCollector, SVCSCollector, FCinfoCollector    
  - 2020 Dec 17. Added PrtdiagCollector, MetaStatCollector, MetaDBCollector
  - 2021 Jan 05. Added TextFileCollector, SVCSCollector now enabled for all zones (Thanks to Marcel Peter)
- - 2021 Mar 01. Fixed psutil version to 5.7.0 (something changed in the newer versions, have to time to look at)
+ - 2021 Mar 01. [Fixed](https://github.com/n27051538/solaris_exporter/issues/4) psutil version to 5.7.0 (something changed in the newer versions, have to time to look at)
  - 2022 Jan 24. Added support for Python 3. In testing.
  - 2022 Feb 04. Documentation update for support of Solaris 11.4.41. In testing.
+ - 2022 Feb 05. [Fixed](https://github.com/n27051538/solaris_exporter/issues/7) support of Python 2.7 for Solaris 11.4.41. In testing.
 
 ## Provides info about:
   - Solaris Zones CPU Usage with processor sets info (PerZoneCpuCollector);
@@ -104,7 +105,7 @@ To use this exporter you need Python2.7 or Python3.x and its modules prometheus_
         ln -s /usr/bin/gcc /usr/bin/cc  
         export CFLAGS=-m32  
         pip-2.7 install psutil==5.7.0  
-        # if you have troubeles with compilation, try to switch to gcc-c-5 and Python 3.7   
+        # if you have troubles with compilation, try to switch to gcc-c-9 and Python 3.7   
     # Run exporter, check http://ip:9100  
         export LANG=C  
         python2.7 solaris_exporter.py  
@@ -118,7 +119,7 @@ To use this exporter you need Python2.7 or Python3.x and its modules prometheus_
             pip-3.7 install prometheus_client  
     # Install Python 3.7 module psutil  
     # Also you could get psutil for Python 3.7 via 'pkg install library/python/psutil-37',  
-    # but its old version '5.6.7' not adapted for Sol11.4.41 changes, it fails at 'swap -l' output.  
+    # but its old version '5.6.7' not adapted for Sol11.4.41 changes, fails at 'swap -l' output, have network dev inaccuracy. 
     # The best way is to install actual version of psutil (tested on '5.9.0')   
         pkg install pkg:/developer/gcc/gcc-c-9  
         ln -s /usr/bin/gcc /usr/bin/cc  

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Pic2
 
 ## Installation. 
 To use this exporter you need Python2.7 or Python3.x and its modules prometheus_client, psutil.
-
+ 
 ###Solaris 10u11:
     # Setup proxy vars to have access to internet  
         export http_proxy=http://proxy.example.com:3128  
@@ -88,8 +88,8 @@ To use this exporter you need Python2.7 or Python3.x and its modules prometheus_
         # or Python 3.3  
         export LANG=C  
         /opt/csw/bin/python3.3 solaris_exporter.py  
-
-
+ 
+ 
 ####Solaris 11.4.4 (this way works with Python 2.7, it is included in this release):
     # Setup proxy vars to have access to internet  
         export http_proxy=http://proxy.example.com:3128  
@@ -108,8 +108,8 @@ To use this exporter you need Python2.7 or Python3.x and its modules prometheus_
     # Run exporter, check http://ip:9100  
         export LANG=C  
         python2.7 solaris_exporter.py  
-
-
+ 
+ 
 ####Solaris 11.4.41 (this way works with Python 3.7):
     # Setup proxy vars to have access to internet  
             export http_proxy=http://proxy.example.com:3128  

--- a/README.md
+++ b/README.md
@@ -46,86 +46,87 @@ Pic2
 To use this exporter you need Python2.7 or Python3.x and its modules prometheus_client, psutil.
 
 ###Solaris 10u11:
-        # Setup proxy vars to have access to internet
-            export http_proxy=http://proxy.example.com:3128
-            export https_proxy=http://proxy.example.com:3128
-        # Install pkgutil
-            wget http://get.opencsw.org/now 
-            pkgadd -d ./now
-        # Update repo list
-            /opt/csw/bin/pkgutil -U
-        # Install Python 2.7 or Python 3.3 (it works on both)
-            # Python 2.7 (preferred)
-                /opt/csw/bin/pkgutil -y -i python27
-                /opt/csw/bin/pkgutil -y -i python27_dev
-                /opt/csw/bin/pkgutil -y -i py_pip
-                /usr/sbin/pkgchk -L CSWpy-pip               # list installed files if you need
-            # or Python 3.3
-                /opt/csw/bin/pkgutil -y -i python33
-                /opt/csw/bin/pkgutil -y -i python33_dev
-                # pip3 is not included in pkgutil, we need to install it by hands
-                # download pip3.3 installer [https://bootstrap.pypa.io/pip/3.3/get-pip.py] and run it with python3.3
-                /opt/csw/bin/python3.3 get-pip.py
-        #Install gcc5core
-            /opt/csw/bin/pkgutil -y -i gcc5core
-        # Install Python module prometheus_client
-            # Python 2.7
-                /opt/csw/bin/pip2.7 install prometheus_client
-            # or Python 3.3
-                /opt/csw/bin/pip3.3 install prometheus_client
-        # Install Python module psutil, it have to compile some libs, but we preinstalled all that needed
-            ln -s /opt/csw/bin/gcc-5.5 /opt/csw/bin/gcc-5.2
-            # Python 2.7
-                # note that the latest version of psutil not supports Python2.7,
-                # that is why version of psutil is fixed to '5.7.0'
-                    /opt/csw/bin/pip2.7 install psutil==5.7.0
-            # or Python 3.3
-                /opt/csw/bin/pip3.3 install psutil
-        # Run exporter, check http://ip:9100
-            # Python 2.7
-            export LANG=C
-            /opt/csw/bin/python2.7 solaris_exporter.py
-            # or Python 3.3
-            export LANG=C
-            /opt/csw/bin/python3.3 solaris_exporter.py
+    # Setup proxy vars to have access to internet  
+        export http_proxy=http://proxy.example.com:3128  
+        export https_proxy=http://proxy.example.com:3128  
+    # Install pkgutil  
+        wget http://get.opencsw.org/now   
+        pkgadd -d ./now   
+    # Update repo list  
+        /opt/csw/bin/pkgutil -U  
+    # Install Python 2.7 or Python 3.3 (it works on both)  
+        # Python 2.7 (preferred)  
+            /opt/csw/bin/pkgutil -y -i python27  
+            /opt/csw/bin/pkgutil -y -i python27_dev  
+            /opt/csw/bin/pkgutil -y -i py_pip  
+            /usr/sbin/pkgchk -L CSWpy-pip               # list installed files if you need  
+        # or Python 3.3  
+            /opt/csw/bin/pkgutil -y -i python33  
+            /opt/csw/bin/pkgutil -y -i python33_dev  
+            # pip3 is not included in pkgutil, we need to install it by hands  
+            # download pip3.3 installer [https://bootstrap.pypa.io/pip/3.3/get-pip.py] and run it with python3.3  
+            /opt/csw/bin/python3.3 get-pip.py  
+    #Install gcc5core  
+        /opt/csw/bin/pkgutil -y -i gcc5core  
+    # Install Python module prometheus_client  
+        # Python 2.7  
+            /opt/csw/bin/pip2.7 install prometheus_client  
+        # or Python 3.3  
+            /opt/csw/bin/pip3.3 install prometheus_client  
+    # Install Python module psutil, it have to compile some libs, but we preinstalled all that needed  
+        ln -s /opt/csw/bin/gcc-5.5 /opt/csw/bin/gcc-5.2  
+        # Python 2.7  
+            # note that the latest version of psutil not supports Python2.7,  
+            # that is why version of psutil is fixed to '5.7.0'  
+                /opt/csw/bin/pip2.7 install psutil==5.7.0  
+        # or Python 3.3  
+            /opt/csw/bin/pip3.3 install psutil  
+    # Run exporter, check http://ip:9100  
+        # Python 2.7  
+        export LANG=C  
+        /opt/csw/bin/python2.7 solaris_exporter.py  
+        # or Python 3.3  
+        export LANG=C  
+        /opt/csw/bin/python3.3 solaris_exporter.py  
 
 
 ####Solaris 11.4.4 (this way works with Python 2.7, it is included in this release):
-        # Setup proxy vars to have access to internet
-            export http_proxy=http://proxy.example.com:3128
-            export https_proxy=http://proxy.example.com:3128
-        # Install Python 2.7 module prometheus_client
-            pip-2.7 install prometheus_client
-        # Install Python 2.7 module psutil, it have to compile some libs
-        # Also you could get psutil for Python 2.7 via 'pkg install library/python/psutil-27',
-        # but it returns wrong Network statistics, tested from Solaris 11.4.4 repo.
-        # The latest version of psutil not supports Python2.7, that is why version of psutil is fixed on '5.7.0'
-            pkg install pkg:/developer/gcc/gcc-c-5
-            ln -s /usr/bin/gcc /usr/bin/cc
-            export CFLAGS=-m32
-            pip-2.7 install psutil==5.7.0
-            # if you have troubeles with compilation, try to switch to gcc-c-5 and Python 3.7 
-        # Run exporter, check http://ip:9100
-            export LANG=C
-            python2.7 solaris_exporter.py
+    # Setup proxy vars to have access to internet  
+        export http_proxy=http://proxy.example.com:3128  
+        export https_proxy=http://proxy.example.com:3128  
+    # Install Python 2.7 module prometheus_client  
+        pip-2.7 install prometheus_client  
+    # Install Python 2.7 module psutil, it have to compile some libs  
+    # Also you could get psutil for Python 2.7 via 'pkg install library/python/psutil-27',  
+    # but it returns wrong Network statistics, tested from Solaris 11.4.4 repo.  
+    # The latest version of psutil not supports Python2.7, that is why version of psutil is fixed on '5.7.0'  
+        pkg install pkg:/developer/gcc/gcc-c-5  
+        ln -s /usr/bin/gcc /usr/bin/cc  
+        export CFLAGS=-m32  
+        pip-2.7 install psutil==5.7.0  
+        # if you have troubeles with compilation, try to switch to gcc-c-5 and Python 3.7   
+    # Run exporter, check http://ip:9100  
+        export LANG=C  
+        python2.7 solaris_exporter.py  
 
 
 ####Solaris 11.4.41 (this way works with Python 3.7):
-        # Setup proxy vars to have access to internet
-            export http_proxy=http://proxy.example.com:3128
-            export https_proxy=http://proxy.example.com:3128
-        # Install Python 3.7 module prometheus_client
-            pip-3.7 install prometheus_client
-        # Install Python 3.7 module psutil
-        # Also you could get psutil for Python 3.7 via 'pkg install library/python/psutil-37',
-        # but its old version '5.6.7' not adapted for Sol11.4.41 changes, it fails at 'swap -l' output.
-        # The best way is to install actual version of psutil (tested on '5.9.0') 
-            pkg install pkg:/developer/gcc/gcc-c-9
-            ln -s /usr/bin/gcc /usr/bin/cc
-            pip-3.7 install psutil==5.9.0
-        # Run exporter, check http://ip:9100
-            export LANG=C
-            python3.7 solaris_exporter.py
+    # Setup proxy vars to have access to internet  
+            export http_proxy=http://proxy.example.com:3128  
+            export https_proxy=http://proxy.example.com:3128  
+    # Install Python 3.7 module prometheus_client  
+            pip-3.7 install prometheus_client  
+    # Install Python 3.7 module psutil  
+    # Also you could get psutil for Python 3.7 via 'pkg install library/python/psutil-37',  
+    # but its old version '5.6.7' not adapted for Sol11.4.41 changes, it fails at 'swap -l' output.  
+    # The best way is to install actual version of psutil (tested on '5.9.0')   
+        pkg install pkg:/developer/gcc/gcc-c-9  
+        ln -s /usr/bin/gcc /usr/bin/cc  
+        pip-3.7 install psutil==5.9.0  
+    # Run exporter, check http://ip:9100  
+        export LANG=C  
+        python3.7 solaris_exporter.py  
+
 
 ## SMF, Roles, Deployment. 
  - Create user and group '**monitor**'

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To use this exporter you need Python2.7 or Python3.x and its modules prometheus_
                 /opt/csw/bin/python3.3 get-pip.py
         #Install gcc5core
             /opt/csw/bin/pkgutil -y -i gcc5core
-        # Install Python module prometheus_client, it installes eassily.
+        # Install Python module prometheus_client
             # Python 2.7
                 /opt/csw/bin/pip2.7 install prometheus_client
             # or Python 3.3
@@ -94,7 +94,7 @@ To use this exporter you need Python2.7 or Python3.x and its modules prometheus_
         # Setup proxy vars to have access to internet
             export http_proxy=http://proxy.example.com:3128
             export https_proxy=http://proxy.example.com:3128
-        # Install Python 2.7 module prometheus_client, it installs easy.
+        # Install Python 2.7 module prometheus_client
             pip-2.7 install prometheus_client
         # Install Python 2.7 module psutil, it have to compile some libs
         # Also you could get psutil for Python 2.7 via 'pkg install library/python/psutil-27',
@@ -114,11 +114,11 @@ To use this exporter you need Python2.7 or Python3.x and its modules prometheus_
         # Setup proxy vars to have access to internet
             export http_proxy=http://proxy.example.com:3128
             export https_proxy=http://proxy.example.com:3128
-        # Install Python 3.7 module prometheus_client, it installs easу.
+        # Install Python 3.7 module prometheus_client
             pip-3.7 install prometheus_client
         # Install Python 3.7 module psutil
         # Also you could get psutil for Python 3.7 via 'pkg install library/python/psutil-37',
-        # but its old version '5.6.7' returns wrong Network statistics, tested from Solaris 11.4.41 repo.
+        # but its old version '5.6.7' not adapted for Sol11.4.41 changes, it fails at 'swap -l' output.
         # The best way is to install actual version of psutil (tested on '5.9.0') 
             pkg install pkg:/developer/gcc/gcc-c-9
             ln -s /usr/bin/gcc /usr/bin/cc

--- a/solaris_exporter.py
+++ b/solaris_exporter.py
@@ -60,7 +60,7 @@ Installation. To use this exporter you need python2.7 or python3.x and its modul
                 /opt/csw/bin/python3.3 get-pip.py
         #Install gcc5core
             /opt/csw/bin/pkgutil -y -i gcc5core
-        # Install Python module prometheus_client, it installes eassily.
+        # Install Python module prometheus_client
             # Python 2.7
                 /opt/csw/bin/pip2.7 install prometheus_client
             # or Python 3.3
@@ -86,7 +86,7 @@ Installation. To use this exporter you need python2.7 or python3.x and its modul
         # Setup proxy vars to have access to internet
             export http_proxy=http://proxy.example.com:3128
             export https_proxy=http://proxy.example.com:3128
-        # Install Python 2.7 module prometheus_client, it installs easy.
+        # Install Python 2.7 module prometheus_client
             pip-2.7 install prometheus_client
         # Install Python 2.7 module psutil, it have to compile some libs
         # Also you could get psutil for Python 2.7 via 'pkg install library/python/psutil-27',
@@ -105,11 +105,11 @@ Installation. To use this exporter you need python2.7 or python3.x and its modul
         # Setup proxy vars to have access to internet
             export http_proxy=http://proxy.example.com:3128
             export https_proxy=http://proxy.example.com:3128
-        # Install Python 3.7 module prometheus_client, it installs easу.
+        # Install Python 3.7 module prometheus_client
             pip-3.7 install prometheus_client
         # Install Python 3.7 module psutil
         # Also you could get psutil for Python 3.7 via 'pkg install library/python/psutil-37',
-        # but version '5.6.7' returns wrong Network statistics, tested from Solaris 11.4.41 repo.
+        # but its old version '5.6.7' not adapted for Sol11.4.41 changes, it fails at 'swap -l' output.
         # The best way is to install actual version of psutil (tested on '5.9.0')
             pkg install pkg:/developer/gcc/gcc-c-9
             ln -s /usr/bin/gcc /usr/bin/cc

--- a/solaris_exporter.py
+++ b/solaris_exporter.py
@@ -15,8 +15,8 @@ version v2022Feb05
 
 Written by Alexander Golikov for collecting SPARC Solaris metrics for Prometheus.
 
-Tested on Solaris 11.3.25, 11.4.4, 10u11(limited) SPARC.
-May be it also will work on x86 platform, but this is not tested.
+Tested on Solaris 11.3.25, 11.4.4, 11.4.41, 10u11(limited) SPARC.
+Also work on x86 platform, community-tested with Openindiana (x86) (OI-hipster-minimal-20201031.iso) and Solaris10u11.
 
 This exporter provides info about:
   - Solaris Zones CPU Usage with processor sets info (PerZoneCpuCollector);

--- a/solaris_exporter.py
+++ b/solaris_exporter.py
@@ -8,7 +8,7 @@ version v2022Jan24
     2020 Dec 17. Added PrtdiagCollector, MetaStatCollector, MetaDBCollector
     2021 Jan 05. Added TextFileCollector, SVCSCollector now enabled for all zones (Thanks to Marcel Peter)
     2021 Mar 01. Fixed psutil version to 5.7.0 (something changed in the newer versions, have to time to look at)
-    2022 Jan 24. Added support for Python 3. In testing.
+    2022 Jan 24. Added support for Python 3. In testing. 
 
 Written by Alexander Golikov for collecting SPARC Solaris metrics for Prometheus.
 

--- a/solaris_exporter.py
+++ b/solaris_exporter.py
@@ -489,7 +489,12 @@ class MemCollector(object):
                                                 'python psutil counters, Memory usage in bytes.',
                                                 labels=['host', 'type', 'counter'])
             ram = psutil.virtual_memory()
-            swap = psutil.swap_memory()
+            try:
+                swap = psutil.swap_memory()
+            except ValueError:
+                print('old version of psutil module, skipping memory stat, you need to update it to 5.9.0+ and run '
+                      'Python3.7')
+                return
             worker_stat_mem.add_metric([host_name, 'virtual', 'used'], ram.used)
             worker_stat_mem.add_metric([host_name, 'virtual', 'available'], ram.available)
             worker_stat_mem.add_metric([host_name, 'virtual', 'total'], ram.total)
@@ -1119,4 +1124,3 @@ if __name__ == '__main__':
         except KeyboardInterrupt:
             print("\nExit Requested\n")
             exit()
-


### PR DESCRIPTION
The old version of psutil fails due to changes in `swap -l` command output.

New variant:

    # swap -l
    swapfile                      dev            swaplo      blocks        free encrypted
    /dev/zvol/dsk/bercutroot/swap 248,4               0     8388608     8388608       yes

Old variant:

    $ swap -l
    swapfile                    dev            swaplo      blocks        free
    /dev/zvol/dsk/swapdump/swap 259,1              16   136314864   136314864

The latest version of psutil library 5.9.0 is adapted to this behavior, but the latest version of psutil not supports Python 2.7.
That is why I copied psutil code to local function psutil_local_swap_memory and adapted it.

Also I added support for Python3.7 and updated installation documentation for Python3.